### PR TITLE
Fix interactive session history display in log view (#7)

### DIFF
--- a/src/app/worker_view.rs
+++ b/src/app/worker_view.rs
@@ -144,6 +144,44 @@ impl WorkerView {
             i += 1;
         }
 
+        // ToolUseが1つもない場合は、セッション全体を1つのLogEntryとして作成
+        if entries.is_empty() && !events.is_empty() {
+            let mut prompt_lines = Vec::new();
+            let mut thought_lines = Vec::new();
+            let result_lines = Vec::new();
+
+            // すべてのイベントからAssistantMessageとThinkingBlockを収集
+            for event in events {
+                match event {
+                    SessionEvent::AssistantMessage { text, .. } => {
+                        for line in text.lines() {
+                            prompt_lines.push(line.to_string());
+                        }
+                    }
+                    SessionEvent::ThinkingBlock { content, .. } => {
+                        for line in content.lines() {
+                            thought_lines.push(line.to_string());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            // プロンプトまたは思考内容がある場合のみLogEntryを作成
+            if !prompt_lines.is_empty() || !thought_lines.is_empty() {
+                entries.push(LogEntry {
+                    step_index: 0,
+                    step_name: "Session".to_string(),
+                    prompt_lines,
+                    result_lines,
+                    thought_lines,
+                    status: StepStatus::Success,
+                });
+            }
+        }
+
+        // Debug: created entries.len() LogEntry(ies) from session history.session_id
+
         entries
     }
 }
@@ -255,5 +293,94 @@ mod tests {
             entries[0].result_lines,
             vec!["Output line 1", "Output line 2"]
         );
+    }
+
+    #[test]
+    fn test_convert_session_without_tool_uses() {
+        // ツール使用がないセッション（単なる対話のみ）
+        let history = SessionHistory {
+            session_id: "test-session-no-tools".to_string(),
+            started_at: "2024-01-01T00:00:00Z".to_string(),
+            ended_at: Some("2024-01-01T00:05:00Z".to_string()),
+            prompt: "Just a conversation".to_string(),
+            events: vec![
+                SessionEvent::AssistantMessage {
+                    text: "I understand your question.".to_string(),
+                    timestamp: "2024-01-01T00:01:00Z".to_string(),
+                },
+                SessionEvent::ThinkingBlock {
+                    content: "Let me think about this...".to_string(),
+                    timestamp: "2024-01-01T00:02:00Z".to_string(),
+                },
+                SessionEvent::AssistantMessage {
+                    text: "Here is my answer.".to_string(),
+                    timestamp: "2024-01-01T00:03:00Z".to_string(),
+                },
+            ],
+            total_tool_uses: 0,
+            files_modified: vec![],
+        };
+
+        let entries = WorkerView::convert_session_to_log_entries(&history);
+
+        // ツール使用がない場合、セッション全体が1つのLogEntryとして作成される
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].step_index, 0);
+        assert_eq!(entries[0].step_name, "Session");
+        assert_eq!(
+            entries[0].prompt_lines,
+            vec!["I understand your question.", "Here is my answer."]
+        );
+        assert_eq!(
+            entries[0].thought_lines,
+            vec!["Let me think about this..."]
+        );
+        assert!(entries[0].result_lines.is_empty());
+        assert_eq!(entries[0].status, StepStatus::Success);
+    }
+
+    #[test]
+    fn test_convert_empty_session() {
+        // イベントが空のセッション
+        let history = SessionHistory {
+            session_id: "empty-session".to_string(),
+            started_at: "2024-01-01T00:00:00Z".to_string(),
+            ended_at: Some("2024-01-01T00:01:00Z".to_string()),
+            prompt: "Empty".to_string(),
+            events: vec![],
+            total_tool_uses: 0,
+            files_modified: vec![],
+        };
+
+        let entries = WorkerView::convert_session_to_log_entries(&history);
+
+        // イベントが空の場合はLogEntryも作成されない
+        assert_eq!(entries.len(), 0);
+    }
+
+    #[test]
+    fn test_convert_session_with_only_system_events() {
+        // AssistantMessageやThinkingBlockがないセッション
+        let history = SessionHistory {
+            session_id: "system-only-session".to_string(),
+            started_at: "2024-01-01T00:00:00Z".to_string(),
+            ended_at: Some("2024-01-01T00:01:00Z".to_string()),
+            prompt: "System events only".to_string(),
+            events: vec![
+                // 他のイベントタイプがあっても、AssistantMessageやThinkingBlockがなければ何も作成されない
+                SessionEvent::ToolResult {
+                    name: "SomeResult".to_string(),
+                    timestamp: "2024-01-01T00:01:00Z".to_string(),
+                    output: Some("Result without tool use".to_string()),
+                },
+            ],
+            total_tool_uses: 0,
+            files_modified: vec![],
+        };
+
+        let entries = WorkerView::convert_session_to_log_entries(&history);
+
+        // AssistantMessageやThinkingBlockがない場合はLogEntryは作成されない
+        assert_eq!(entries.len(), 0);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #7

インタラクティブモードのセッション履歴がログビューのOverviewタブにステップとして表示されるように修正しました。

### 変更内容

- **ツール使用がないセッションのサポート**: `convert_session_to_log_entries()`にフォールバックロジックを追加し、ツール使用がない場合でもセッション全体を1つのステップとして表示
- **後方互換性の維持**: ツール使用がある場合は従来通り各ツールを個別のステップとして表示
- **テストカバレッジの追加**: 以下の3つのテストケースを追加
  - ツール使用がない対話のみのセッション
  - 空のセッション
  - システムイベントのみのセッション

### 動作

**修正前**:
- インタラクティブモードでツール使用がない場合、Overviewタブに何も表示されない
- セッション履歴は保存されているが可視化されない

**修正後**:
- ツール使用がある場合: 各ツールがステップとして表示（既存動作維持）
- ツール使用がない場合: セッション全体が"Session"という名前で1つのステップとして表示（新機能）
- `AssistantMessage`と`ThinkingBlock`が適切に収集され表示される

### テスト

```bash
cargo test
```

全49個のテストがパスすることを確認済み。

## Test plan

- [x] 全テストが成功することを確認
- [x] ツール使用ありのセッションで既存動作が維持されることを確認
- [x] ツール使用なしのセッションでステップが表示されることを確認
- [ ] 実際にインタラクティブモードを起動して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)