### PR TITLE
Add multiline text input support with enhanced editing features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "time",
+ "tui-textarea",
 ]
 
 [[package]]
@@ -752,6 +753,17 @@ checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tui-textarea"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c07084342a575cea919eea996b9658a358c800b03d435df581c1d7c60e065a"
+dependencies = [
+ "crossterm 0.28.1",
+ "ratatui",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ thiserror = "1"
 time = { version = "0.3", features = ["formatting"] }
 clap = { version = "4", features = ["derive"] }
 regex = "1"
+tui-textarea = "0.6"

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1,3 +1,4 @@
+use tui_textarea::TextArea;
 use crate::ui::{permission_mode_label, LogViewMode};
 use crate::worker::{CreateWorkerRequest, WorkerId, WorkerStatus, list_existing_worktrees};
 
@@ -13,7 +14,7 @@ impl App {
             .map(|wf| wf.name.clone());
 
         self.input_mode = Some(InputMode::NameInput {
-            buffer: String::new(),
+            textarea: TextArea::default(),
             workflow_name,
             next_action: NameInputNextAction::CreateWithWorkflow,
         });
@@ -21,7 +22,7 @@ impl App {
 
     pub fn show_name_input_for_free_prompt(&mut self) {
         self.input_mode = Some(InputMode::NameInput {
-            buffer: String::new(),
+            textarea: TextArea::default(),
             workflow_name: None,
             next_action: NameInputNextAction::CreateWithFreePrompt,
         });
@@ -54,7 +55,7 @@ impl App {
     pub fn show_rename_modal(&mut self) {
         if let Some(id) = self.selected_worker_id() {
             self.input_mode = Some(InputMode::RenameWorker {
-                buffer: String::new(),
+                textarea: TextArea::default(),
                 worker_id: id,
             });
         } else {
@@ -336,7 +337,7 @@ impl App {
 
     pub fn start_free_prompt(&mut self) {
         self.input_mode = Some(InputMode::FreePrompt {
-            buffer: String::new(),
+            textarea: TextArea::default(),
             force_new: false,
             permission_mode: None,
             worker_name: None,

--- a/src/app/event_handler.rs
+++ b/src/app/event_handler.rs
@@ -203,8 +203,15 @@ impl App {
                         return false;
                     }
 
-                    // Handle Ctrl+Enter to submit
-                    if key_event.code == KeyCode::Enter && key_event.modifiers.contains(KeyModifiers::CONTROL) {
+                    // Handle Ctrl+J to add newline
+                    if key_event.code == KeyCode::Char('j') && key_event.modifiers.contains(KeyModifiers::CONTROL) {
+                        let input = key_event_to_input(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()));
+                        textarea.input(input);
+                        return false;
+                    }
+
+                    // Handle Enter to submit (without modifiers)
+                    if key_event.code == KeyCode::Enter && key_event.modifiers.is_empty() {
                         let prompt = textarea.lines().join("\n");
                         let is_force_new = *force_new;
                         let mode = permission_mode.clone();

--- a/src/app/event_handler.rs
+++ b/src/app/event_handler.rs
@@ -1,12 +1,110 @@
 use std::collections::HashMap;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use tui_textarea::Input;
 
 use crate::ui::{permission_mode_label, describe_allowed_tools, AVAILABLE_TOOLS, LogViewMode};
 use crate::worker::{PermissionDecision, PermissionRequest, WorkerId, WorkerEvent, WorkerStatus};
 
 use super::types::{InputMode, NameInputNextAction};
 use super::App;
+
+/// Convert crossterm KeyEvent to ratatui's crossterm KeyEvent for tui-textarea
+fn key_event_to_input(key_event: KeyEvent) -> Input {
+    // Convert crossterm KeyEvent to ratatui::crossterm::event::KeyEvent
+    // They have the same structure, so we can recreate it
+    let ratatui_key_event = ratatui::crossterm::event::KeyEvent::new(
+        match key_event.code {
+            KeyCode::Backspace => ratatui::crossterm::event::KeyCode::Backspace,
+            KeyCode::Enter => ratatui::crossterm::event::KeyCode::Enter,
+            KeyCode::Left => ratatui::crossterm::event::KeyCode::Left,
+            KeyCode::Right => ratatui::crossterm::event::KeyCode::Right,
+            KeyCode::Up => ratatui::crossterm::event::KeyCode::Up,
+            KeyCode::Down => ratatui::crossterm::event::KeyCode::Down,
+            KeyCode::Home => ratatui::crossterm::event::KeyCode::Home,
+            KeyCode::End => ratatui::crossterm::event::KeyCode::End,
+            KeyCode::PageUp => ratatui::crossterm::event::KeyCode::PageUp,
+            KeyCode::PageDown => ratatui::crossterm::event::KeyCode::PageDown,
+            KeyCode::Tab => ratatui::crossterm::event::KeyCode::Tab,
+            KeyCode::BackTab => ratatui::crossterm::event::KeyCode::BackTab,
+            KeyCode::Delete => ratatui::crossterm::event::KeyCode::Delete,
+            KeyCode::Insert => ratatui::crossterm::event::KeyCode::Insert,
+            KeyCode::F(n) => ratatui::crossterm::event::KeyCode::F(n),
+            KeyCode::Char(c) => ratatui::crossterm::event::KeyCode::Char(c),
+            KeyCode::Null => ratatui::crossterm::event::KeyCode::Null,
+            KeyCode::Esc => ratatui::crossterm::event::KeyCode::Esc,
+            KeyCode::CapsLock => ratatui::crossterm::event::KeyCode::CapsLock,
+            KeyCode::ScrollLock => ratatui::crossterm::event::KeyCode::ScrollLock,
+            KeyCode::NumLock => ratatui::crossterm::event::KeyCode::NumLock,
+            KeyCode::PrintScreen => ratatui::crossterm::event::KeyCode::PrintScreen,
+            KeyCode::Pause => ratatui::crossterm::event::KeyCode::Pause,
+            KeyCode::Menu => ratatui::crossterm::event::KeyCode::Menu,
+            KeyCode::KeypadBegin => ratatui::crossterm::event::KeyCode::KeypadBegin,
+            KeyCode::Media(m) => {
+                use crossterm::event::MediaKeyCode;
+                match m {
+                    MediaKeyCode::Play => ratatui::crossterm::event::KeyCode::Media(ratatui::crossterm::event::MediaKeyCode::Play),
+                    MediaKeyCode::Pause => ratatui::crossterm::event::KeyCode::Media(ratatui::crossterm::event::MediaKeyCode::Pause),
+                    MediaKeyCode::PlayPause => ratatui::crossterm::event::KeyCode::Media(ratatui::crossterm::event::MediaKeyCode::PlayPause),
+                    MediaKeyCode::Reverse => ratatui::crossterm::event::KeyCode::Media(ratatui::crossterm::event::MediaKeyCode::Reverse),
+                    MediaKeyCode::Stop => ratatui::crossterm::event::KeyCode::Media(ratatui::crossterm::event::MediaKeyCode::Stop),
+                    MediaKeyCode::FastForward => ratatui::crossterm::event::KeyCode::Media(ratatui::crossterm::event::MediaKeyCode::FastForward),
+                    MediaKeyCode::Rewind => ratatui::crossterm::event::KeyCode::Media(ratatui::crossterm::event::MediaKeyCode::Rewind),
+                    MediaKeyCode::TrackNext => ratatui::crossterm::event::KeyCode::Media(ratatui::crossterm::event::MediaKeyCode::TrackNext),
+                    MediaKeyCode::TrackPrevious => ratatui::crossterm::event::KeyCode::Media(ratatui::crossterm::event::MediaKeyCode::TrackPrevious),
+                    MediaKeyCode::Record => ratatui::crossterm::event::KeyCode::Media(ratatui::crossterm::event::MediaKeyCode::Record),
+                    MediaKeyCode::LowerVolume => ratatui::crossterm::event::KeyCode::Media(ratatui::crossterm::event::MediaKeyCode::LowerVolume),
+                    MediaKeyCode::RaiseVolume => ratatui::crossterm::event::KeyCode::Media(ratatui::crossterm::event::MediaKeyCode::RaiseVolume),
+                    MediaKeyCode::MuteVolume => ratatui::crossterm::event::KeyCode::Media(ratatui::crossterm::event::MediaKeyCode::MuteVolume),
+                }
+            },
+            KeyCode::Modifier(m) => {
+                use crossterm::event::ModifierKeyCode;
+                match m {
+                    ModifierKeyCode::LeftShift => ratatui::crossterm::event::KeyCode::Modifier(ratatui::crossterm::event::ModifierKeyCode::LeftShift),
+                    ModifierKeyCode::LeftControl => ratatui::crossterm::event::KeyCode::Modifier(ratatui::crossterm::event::ModifierKeyCode::LeftControl),
+                    ModifierKeyCode::LeftAlt => ratatui::crossterm::event::KeyCode::Modifier(ratatui::crossterm::event::ModifierKeyCode::LeftAlt),
+                    ModifierKeyCode::LeftSuper => ratatui::crossterm::event::KeyCode::Modifier(ratatui::crossterm::event::ModifierKeyCode::LeftSuper),
+                    ModifierKeyCode::LeftHyper => ratatui::crossterm::event::KeyCode::Modifier(ratatui::crossterm::event::ModifierKeyCode::LeftHyper),
+                    ModifierKeyCode::LeftMeta => ratatui::crossterm::event::KeyCode::Modifier(ratatui::crossterm::event::ModifierKeyCode::LeftMeta),
+                    ModifierKeyCode::RightShift => ratatui::crossterm::event::KeyCode::Modifier(ratatui::crossterm::event::ModifierKeyCode::RightShift),
+                    ModifierKeyCode::RightControl => ratatui::crossterm::event::KeyCode::Modifier(ratatui::crossterm::event::ModifierKeyCode::RightControl),
+                    ModifierKeyCode::RightAlt => ratatui::crossterm::event::KeyCode::Modifier(ratatui::crossterm::event::ModifierKeyCode::RightAlt),
+                    ModifierKeyCode::RightSuper => ratatui::crossterm::event::KeyCode::Modifier(ratatui::crossterm::event::ModifierKeyCode::RightSuper),
+                    ModifierKeyCode::RightHyper => ratatui::crossterm::event::KeyCode::Modifier(ratatui::crossterm::event::ModifierKeyCode::RightHyper),
+                    ModifierKeyCode::RightMeta => ratatui::crossterm::event::KeyCode::Modifier(ratatui::crossterm::event::ModifierKeyCode::RightMeta),
+                    ModifierKeyCode::IsoLevel3Shift => ratatui::crossterm::event::KeyCode::Modifier(ratatui::crossterm::event::ModifierKeyCode::IsoLevel3Shift),
+                    ModifierKeyCode::IsoLevel5Shift => ratatui::crossterm::event::KeyCode::Modifier(ratatui::crossterm::event::ModifierKeyCode::IsoLevel5Shift),
+                }
+            },
+        },
+        convert_modifiers(key_event.modifiers),
+    );
+    Input::from(ratatui_key_event)
+}
+
+fn convert_modifiers(modifiers: KeyModifiers) -> ratatui::crossterm::event::KeyModifiers {
+    let mut result = ratatui::crossterm::event::KeyModifiers::empty();
+    if modifiers.contains(KeyModifiers::SHIFT) {
+        result.insert(ratatui::crossterm::event::KeyModifiers::SHIFT);
+    }
+    if modifiers.contains(KeyModifiers::CONTROL) {
+        result.insert(ratatui::crossterm::event::KeyModifiers::CONTROL);
+    }
+    if modifiers.contains(KeyModifiers::ALT) {
+        result.insert(ratatui::crossterm::event::KeyModifiers::ALT);
+    }
+    if modifiers.contains(KeyModifiers::SUPER) {
+        result.insert(ratatui::crossterm::event::KeyModifiers::SUPER);
+    }
+    if modifiers.contains(KeyModifiers::HYPER) {
+        result.insert(ratatui::crossterm::event::KeyModifiers::HYPER);
+    }
+    if modifiers.contains(KeyModifiers::META) {
+        result.insert(ratatui::crossterm::event::KeyModifiers::META);
+    }
+    result
+}
 
 impl App {
     /// Handle keyboard input
@@ -83,49 +181,46 @@ impl App {
         if let Some(mode) = self.input_mode.as_mut() {
             match mode {
                 InputMode::FreePrompt {
-                    buffer,
+                    textarea,
                     force_new,
                     permission_mode,
                     worker_name,
-                } => match key_event.code {
-                    KeyCode::Esc => {
-                        self.input_mode = None;
-                    }
-                    KeyCode::Enter => {
-                        let prompt = buffer.trim().to_string();
-                        let is_force_new = *force_new;
-                        let mode = permission_mode.clone();
-                        let name = worker_name.clone();
-                        self.input_mode = None;
-                        if !prompt.is_empty() {
-                            self.submit_free_prompt(prompt, is_force_new, mode, name);
-                        } else {
-                            self.push_log("空の指示は送信されませんでした".into());
-                        }
-                    }
-                    KeyCode::Backspace => {
-                        buffer.pop();
-                    }
-                    KeyCode::Tab => {
-                        buffer.push('\t');
-                    }
-                    KeyCode::Char('p') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-                        // Cycle through: None -> "plan" -> "acceptEdits" -> None
+                } => {
+                    // Handle Ctrl+P for permission mode cycling
+                    if key_event.code == KeyCode::Char('p') && key_event.modifiers.contains(KeyModifiers::CONTROL) {
                         *permission_mode = match permission_mode.as_deref() {
                             None => Some("plan".to_string()),
                             Some("plan") => Some("acceptEdits".to_string()),
                             Some("acceptEdits") => None,
                             _ => None,
                         };
+                        return false;
                     }
-                    KeyCode::Char(c) => {
-                        if !key_event.modifiers.contains(KeyModifiers::CONTROL)
-                            && !key_event.modifiers.contains(KeyModifiers::ALT)
-                        {
-                            buffer.push(c);
+
+                    // Handle Esc to cancel
+                    if key_event.code == KeyCode::Esc {
+                        self.input_mode = None;
+                        return false;
+                    }
+
+                    // Handle Ctrl+Enter to submit
+                    if key_event.code == KeyCode::Enter && key_event.modifiers.contains(KeyModifiers::CONTROL) {
+                        let prompt = textarea.lines().join("\n");
+                        let is_force_new = *force_new;
+                        let mode = permission_mode.clone();
+                        let name = worker_name.clone();
+                        self.input_mode = None;
+                        if !prompt.trim().is_empty() {
+                            self.submit_free_prompt(prompt, is_force_new, mode, name);
+                        } else {
+                            self.push_log("空の指示は送信されませんでした".into());
                         }
+                        return false;
                     }
-                    _ => {}
+
+                    // Pass all other keys to TextArea
+                    let input = key_event_to_input(key_event);
+                    textarea.input(input);
                 },
                 InputMode::CreateWorkerSelection { selected } => match key_event.code {
                     KeyCode::Esc => {
@@ -253,9 +348,9 @@ impl App {
                         _ => {}
                     }
                 }
-                InputMode::NameInput { buffer, workflow_name, next_action } => match key_event.code {
-                    KeyCode::Esc => {
-                        // Cancel and use default name
+                InputMode::NameInput { textarea, workflow_name, next_action } => {
+                    // Handle Esc to cancel and use default name
+                    if key_event.code == KeyCode::Esc {
                         let workflow = workflow_name.clone();
                         let action = next_action.clone();
                         self.input_mode = None;
@@ -267,16 +362,19 @@ impl App {
                             NameInputNextAction::CreateWithFreePrompt => {
                                 // Show free prompt modal with default name
                                 self.input_mode = Some(InputMode::FreePrompt {
-                                    buffer: String::new(),
+                                    textarea: tui_textarea::TextArea::default(),
                                     force_new: true,
                                     permission_mode: None,
                                     worker_name: None,
                                 });
                             }
                         }
+                        return false;
                     }
-                    KeyCode::Enter => {
-                        let name = buffer.trim().to_string();
+
+                    // Handle Enter to submit
+                    if key_event.code == KeyCode::Enter {
+                        let name = textarea.lines().join("").trim().to_string();
                         let workflow = workflow_name.clone();
                         let action = next_action.clone();
                         self.input_mode = None;
@@ -295,32 +393,30 @@ impl App {
                                 // Show free prompt modal
                                 let worker_name = if name.is_empty() { None } else { Some(name) };
                                 self.input_mode = Some(InputMode::FreePrompt {
-                                    buffer: String::new(),
+                                    textarea: tui_textarea::TextArea::default(),
                                     force_new: true,
                                     permission_mode: None,
                                     worker_name,
                                 });
                             }
                         }
+                        return false;
                     }
-                    KeyCode::Backspace => {
-                        buffer.pop();
-                    }
-                    KeyCode::Char(c) => {
-                        if !key_event.modifiers.contains(KeyModifiers::CONTROL)
-                            && !key_event.modifiers.contains(KeyModifiers::ALT)
-                        {
-                            buffer.push(c);
-                        }
-                    }
-                    _ => {}
+
+                    // Pass all other keys to TextArea
+                    let input = key_event_to_input(key_event);
+                    textarea.input(input);
                 },
-                InputMode::RenameWorker { buffer, worker_id } => match key_event.code {
-                    KeyCode::Esc => {
+                InputMode::RenameWorker { textarea, worker_id } => {
+                    // Handle Esc to cancel
+                    if key_event.code == KeyCode::Esc {
                         self.input_mode = None;
+                        return false;
                     }
-                    KeyCode::Enter => {
-                        let new_name = buffer.trim().to_string();
+
+                    // Handle Enter to submit
+                    if key_event.code == KeyCode::Enter {
+                        let new_name = textarea.lines().join("").trim().to_string();
                         let wid = *worker_id;
                         self.input_mode = None;
                         if !new_name.is_empty() {
@@ -328,18 +424,12 @@ impl App {
                         } else {
                             self.push_log("空の名前は無効です".into());
                         }
+                        return false;
                     }
-                    KeyCode::Backspace => {
-                        buffer.pop();
-                    }
-                    KeyCode::Char(c) => {
-                        if !key_event.modifiers.contains(KeyModifiers::CONTROL)
-                            && !key_event.modifiers.contains(KeyModifiers::ALT)
-                        {
-                            buffer.push(c);
-                        }
-                    }
-                    _ => {}
+
+                    // Pass all other keys to TextArea
+                    let input = key_event_to_input(key_event);
+                    textarea.input(input);
                 },
             }
             return false;

--- a/src/app/rendering.rs
+++ b/src/app/rendering.rs
@@ -50,11 +50,11 @@ impl App {
         if let Some(input_mode) = &self.input_mode {
             match input_mode {
                 InputMode::FreePrompt {
-                    buffer,
+                    textarea,
                     permission_mode,
                     ..
                 } => {
-                    self.render_prompt_modal(frame, buffer, permission_mode);
+                    self.render_prompt_modal(frame, textarea, permission_mode);
                 }
                 InputMode::CreateWorkerSelection { selected } => {
                     self.render_create_selection_modal(frame, *selected);
@@ -73,12 +73,12 @@ impl App {
                 } => {
                     self.render_tool_selection_modal(frame, tools, *selected_idx, permission_mode);
                 }
-                InputMode::NameInput { buffer, workflow_name, .. } => {
-                    self.render_name_input_modal(frame, buffer, workflow_name);
+                InputMode::NameInput { textarea, workflow_name, .. } => {
+                    self.render_name_input_modal(frame, textarea, workflow_name);
                 }
-                InputMode::RenameWorker { buffer, worker_id } => {
+                InputMode::RenameWorker { textarea, worker_id } => {
                     if let Some(worker) = self.workers.iter().find(|w| w.snapshot.id == *worker_id) {
-                        self.render_rename_worker_modal(frame, buffer, &worker.snapshot.name);
+                        self.render_rename_worker_modal(frame, textarea, &worker.snapshot.name);
                     }
                 }
             }
@@ -136,11 +136,11 @@ impl App {
     fn render_prompt_modal(
         &self,
         frame: &mut ratatui::Frame<'_>,
-        buffer: &str,
+        textarea: &tui_textarea::TextArea<'_>,
         permission_mode: &Option<String>,
     ) {
-        let area = centered_rect(70, 30, frame.area());
-        render_prompt_modal(frame, area, buffer, permission_mode);
+        let area = centered_rect(70, 50, frame.area());
+        render_prompt_modal(frame, area, textarea, permission_mode);
     }
 
     fn render_permission_modal(
@@ -188,21 +188,21 @@ impl App {
     fn render_name_input_modal(
         &self,
         frame: &mut ratatui::Frame<'_>,
-        buffer: &str,
+        textarea: &tui_textarea::TextArea<'_>,
         workflow_name: &Option<String>,
     ) {
         let area = centered_rect(60, 40, frame.area());
-        render_name_input_modal(frame, area, buffer, workflow_name);
+        render_name_input_modal(frame, area, textarea, workflow_name);
     }
 
     fn render_rename_worker_modal(
         &self,
         frame: &mut ratatui::Frame<'_>,
-        buffer: &str,
+        textarea: &tui_textarea::TextArea<'_>,
         current_name: &str,
     ) {
         let area = centered_rect(60, 40, frame.area());
-        render_rename_worker_modal(frame, area, buffer, current_name);
+        render_rename_worker_modal(frame, area, textarea, current_name);
     }
 
     pub fn help_lines(&self) -> Vec<Line<'static>> {

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use tui_textarea::TextArea;
 use crate::worker::{ExistingWorktree, PermissionDecision, PermissionRequest, WorkerId};
 
 /// Input modes for the TUI
 pub enum InputMode {
     FreePrompt {
-        buffer: String,
+        textarea: TextArea<'static>,
         force_new: bool,
         permission_mode: Option<String>,
         worker_name: Option<String>,
@@ -26,12 +27,12 @@ pub enum InputMode {
         request_id: u64,                // permission request ID
     },
     NameInput {
-        buffer: String,
+        textarea: TextArea<'static>,
         workflow_name: Option<String>,
         next_action: NameInputNextAction,
     },
     RenameWorker {
-        buffer: String,
+        textarea: TextArea<'static>,
         worker_id: WorkerId,
     },
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -35,14 +35,16 @@ pub fn render_modal(
 /// # Arguments
 /// * `frame` - 描画フレーム
 /// * `area` - 描画領域
-/// * `buffer` - 入力バッファ
+/// * `textarea` - テキストエリア
 /// * `permission_mode` - パーミッションモード
 pub fn render_prompt_modal(
     frame: &mut ratatui::Frame<'_>,
     area: Rect,
-    buffer: &str,
+    textarea: &tui_textarea::TextArea<'_>,
     permission_mode: &Option<String>,
 ) {
+    use ratatui::layout::{Constraint, Layout, Direction};
+
     let mode_str = permission_mode_label(permission_mode);
     let mode_color = match permission_mode.as_deref() {
         Some("plan") => Color::Cyan,
@@ -50,18 +52,37 @@ pub fn render_prompt_modal(
         _ => Color::Green,
     };
 
-    let lines = vec![
-        Line::raw(
-            "自由指示を入力してください (Enterで送信 / Escでキャンセル / Ctrl+Pでモード切替)",
-        ),
-        Line::raw(""),
-        Line::from(Span::styled(
-            buffer,
-            Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD),
-        )),
-        Line::raw(""),
+    // Split area into header, textarea, and footer
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),  // Header
+            Constraint::Min(5),     // TextArea
+            Constraint::Length(3),  // Footer
+        ])
+        .split(area);
+
+    // Clear the background
+    frame.render_widget(Clear, area);
+
+    // Render header
+    let header_lines = vec![
+        Line::raw("自由指示を入力してください (Ctrl+Enterで送信 / Escでキャンセル / Ctrl+Pでモード切替)"),
+    ];
+    let header = Paragraph::new(header_lines)
+        .block(Block::default().borders(Borders::TOP | Borders::LEFT | Borders::RIGHT).title("Free Prompt"));
+    frame.render_widget(header, chunks[0]);
+
+    // Render TextArea in the middle
+    let textarea_block = Block::default()
+        .borders(Borders::LEFT | Borders::RIGHT)
+        .style(Style::default().fg(Color::Yellow));
+    let mut textarea_clone = textarea.clone();
+    textarea_clone.set_block(textarea_block);
+    frame.render_widget(&textarea_clone, chunks[1]);
+
+    // Render footer
+    let footer_lines = vec![
         Line::from(vec![
             Span::raw("モード: "),
             Span::styled(
@@ -71,11 +92,9 @@ pub fn render_prompt_modal(
         ]),
         Line::raw("Claude Codeがheadlessモードで実行されます"),
     ];
-    let widget = Paragraph::new(lines)
-        .wrap(Wrap { trim: false })
-        .block(Block::default().borders(Borders::ALL).title("Free Prompt"));
-    frame.render_widget(Clear, area);
-    frame.render_widget(widget, area);
+    let footer = Paragraph::new(footer_lines)
+        .block(Block::default().borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT));
+    frame.render_widget(footer, chunks[2]);
 }
 
 /// パーミッション確認モーダルをレンダリング
@@ -317,15 +336,31 @@ pub fn render_worktree_selection_modal(
 pub fn render_name_input_modal(
     frame: &mut ratatui::Frame<'_>,
     area: Rect,
-    buffer: &str,
+    textarea: &tui_textarea::TextArea<'_>,
     workflow_name: &Option<String>,
 ) {
+    use ratatui::layout::{Constraint, Layout, Direction};
+
     let workflow_text = workflow_name
         .as_ref()
         .map(|name| format!("ワークフロー: {}", name))
         .unwrap_or_else(|| "新規ワーカー".to_string());
 
-    let lines = vec![
+    // Split area into header, textarea, and footer
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(5),  // Header
+            Constraint::Length(3),  // TextArea
+            Constraint::Length(4),  // Footer
+        ])
+        .split(area);
+
+    // Clear the background
+    frame.render_widget(Clear, area);
+
+    // Render header
+    let header_lines = vec![
         Line::from(Span::styled(
             "Worker名を入力してください",
             Style::default()
@@ -334,46 +369,60 @@ pub fn render_name_input_modal(
         )),
         Line::raw(""),
         Line::raw(&workflow_text),
-        Line::raw(""),
-        Line::from(vec![
-            Span::raw("名前: "),
-            Span::styled(
-                buffer,
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            ),
-        ]),
-        Line::raw(""),
+    ];
+    let header = Paragraph::new(header_lines)
+        .block(Block::default().borders(Borders::TOP | Borders::LEFT | Borders::RIGHT).title("Worker Name"));
+    frame.render_widget(header, chunks[0]);
+
+    // Render TextArea in the middle
+    let textarea_block = Block::default()
+        .borders(Borders::LEFT | Borders::RIGHT)
+        .style(Style::default().fg(Color::Yellow));
+    let mut textarea_clone = textarea.clone();
+    textarea_clone.set_block(textarea_block);
+    frame.render_widget(&textarea_clone, chunks[1]);
+
+    // Render footer
+    let footer_lines = vec![
         Line::raw("Enter: 確定 / Esc: スキップ（デフォルト名を使用）"),
         Line::raw(""),
         Line::from(vec![
-            Span::styled(
-                "※",
-                Style::default().fg(Color::Gray),
-            ),
+            Span::styled("※", Style::default().fg(Color::Gray)),
             Span::styled(
                 " 使用可能: 英数字、ハイフン、アンダースコア、日本語 (1-64文字)",
                 Style::default().fg(Color::Gray),
             ),
         ]),
     ];
-
-    let widget = Paragraph::new(lines)
-        .wrap(Wrap { trim: false })
-        .block(Block::default().borders(Borders::ALL).title("Worker Name"));
-    frame.render_widget(Clear, area);
-    frame.render_widget(widget, area);
+    let footer = Paragraph::new(footer_lines)
+        .block(Block::default().borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT));
+    frame.render_widget(footer, chunks[2]);
 }
 
 /// Worker名前変更モーダルをレンダリング
 pub fn render_rename_worker_modal(
     frame: &mut ratatui::Frame<'_>,
     area: Rect,
-    buffer: &str,
+    textarea: &tui_textarea::TextArea<'_>,
     current_name: &str,
 ) {
-    let lines = vec![
+    use ratatui::layout::{Constraint, Layout, Direction};
+
+    // Split area into header, textarea, and footer
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(5),  // Header
+            Constraint::Length(3),  // TextArea
+            Constraint::Length(4),  // Footer
+        ])
+        .split(area);
+
+    // Clear the background
+    frame.render_widget(Clear, area);
+
+    // Render header
+    let header_lines = vec![
         Line::from(Span::styled(
             "Worker名を変更",
             Style::default()
@@ -383,41 +432,36 @@ pub fn render_rename_worker_modal(
         Line::raw(""),
         Line::from(vec![
             Span::raw("現在の名前: "),
-            Span::styled(
-                current_name,
-                Style::default().fg(Color::Gray),
-            ),
+            Span::styled(current_name, Style::default().fg(Color::Gray)),
         ]),
-        Line::raw(""),
-        Line::from(vec![
-            Span::raw("新しい名前: "),
-            Span::styled(
-                buffer,
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            ),
-        ]),
-        Line::raw(""),
+    ];
+    let header = Paragraph::new(header_lines)
+        .block(Block::default().borders(Borders::TOP | Borders::LEFT | Borders::RIGHT).title("Rename Worker"));
+    frame.render_widget(header, chunks[0]);
+
+    // Render TextArea in the middle
+    let textarea_block = Block::default()
+        .borders(Borders::LEFT | Borders::RIGHT)
+        .style(Style::default().fg(Color::Yellow));
+    let mut textarea_clone = textarea.clone();
+    textarea_clone.set_block(textarea_block);
+    frame.render_widget(&textarea_clone, chunks[1]);
+
+    // Render footer
+    let footer_lines = vec![
         Line::raw("Enter: 確定 / Esc: キャンセル"),
         Line::raw(""),
         Line::from(vec![
-            Span::styled(
-                "※",
-                Style::default().fg(Color::Gray),
-            ),
+            Span::styled("※", Style::default().fg(Color::Gray)),
             Span::styled(
                 " 使用可能: 英数字、ハイフン、アンダースコア、日本語 (1-64文字)",
                 Style::default().fg(Color::Gray),
             ),
         ]),
     ];
-
-    let widget = Paragraph::new(lines)
-        .wrap(Wrap { trim: false })
-        .block(Block::default().borders(Borders::ALL).title("Rename Worker"));
-    frame.render_widget(Clear, area);
-    frame.render_widget(widget, area);
+    let footer = Paragraph::new(footer_lines)
+        .block(Block::default().borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT));
+    frame.render_widget(footer, chunks[2]);
 }
 
 /// 許可されたツールの説明テキストを生成

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -67,7 +67,7 @@ pub fn render_prompt_modal(
 
     // Render header
     let header_lines = vec![
-        Line::raw("自由指示を入力してください (Ctrl+Enterで送信 / Escでキャンセル / Ctrl+Pでモード切替)"),
+        Line::raw("自由指示を入力してください (Enterで送信 / Ctrl+Jで改行 / Escでキャンセル / Ctrl+Pでモード切替)"),
     ];
     let header = Paragraph::new(header_lines)
         .block(Block::default().borders(Borders::TOP | Borders::LEFT | Borders::RIGHT).title("Free Prompt"));

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -272,7 +272,7 @@ pub fn help_lines() -> Vec<Line<'static>> {
         Line::raw("q – 終了"),
         Line::raw(""),
         Line::raw("入力モーダル操作:"),
-        Line::raw("  プロンプト入力: Ctrl+Enter で送信 / Esc でキャンセル"),
+        Line::raw("  プロンプト入力: Enter で送信 / Ctrl+J で改行 / Esc でキャンセル"),
         Line::raw("  名前入力/変更: Enter で確定 / Esc でキャンセル"),
         Line::raw("  矢印キー/Home/End でカーソル移動、複数行入力可能"),
         Line::raw(""),

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -271,6 +271,11 @@ pub fn help_lines() -> Vec<Line<'static>> {
         Line::raw("Shift+A – ログの自動スクロールON/OFF切替"),
         Line::raw("q – 終了"),
         Line::raw(""),
+        Line::raw("入力モーダル操作:"),
+        Line::raw("  プロンプト入力: Ctrl+Enter で送信 / Esc でキャンセル"),
+        Line::raw("  名前入力/変更: Enter で確定 / Esc でキャンセル"),
+        Line::raw("  矢印キー/Home/End でカーソル移動、複数行入力可能"),
+        Line::raw(""),
         Line::raw("ステータス: Running/Idle/Paused/Failed/Archived(青=履歴)"),
     ]
 }


### PR DESCRIPTION
## Summary

- マルチラインテキスト入力のサポートを追加
- キーバインディングの改善: Enterで送信、Ctrl+Jで改行
- `tui-textarea` クレートを導入してより豊富な編集機能を提供

## Changes

### 主な機能追加

1. **マルチラインテキスト入力**
   - `tui-textarea` クレート (v0.6.1) を追加
   - すべての入力モード（FreePrompt、NameInput、RenameWorker）で `String` → `TextArea` に変更
   - 複数行の入力が可能になり、長いプロンプトの編集が容易に

2. **キーバインディングの改善**
   - **Enter**: プロンプトを送信（モディファイアなし）
   - **Ctrl+J**: 新しい行を挿入（改行）
   - **Esc**: キャンセル（既存）
   - **Ctrl+P**: パーミッションモード切替（既存）

3. **UI/UX の改善**
   - モーダルの高さを 30% → 50% に拡大し、より多くのテキストを表示
   - レイアウトを改善（ヘッダー、テキストエリア、フッターの分離）
   - キー操作のヘルプテキストを更新

### 技術的な変更

- `key_event_to_input()` 関数: crossterm の `KeyEvent` を ratatui の `Input` に変換
- `convert_modifiers()` 関数: キーモディファイアの変換
- イベントハンドリングロジックの改善

## Modified Files

- `Cargo.toml`, `Cargo.lock`: 依存関係の追加
- `src/app/types.rs`: 型定義の更新
- `src/app/actions.rs`: TextArea の初期化
- `src/app/event_handler.rs`: キーイベント処理の改善
- `src/app/rendering.rs`: レンダリングロジックの更新
- `src/ui/modals.rs`: モーダルUIの改善

## Test plan

- [ ] 自由プロンプト入力で複数行のテキストを入力できる
- [ ] Enterキーでプロンプトが送信される
- [ ] Ctrl+Jで改行が挿入される
- [ ] ワーカー名入力でテキストエリアが正常に動作する
- [ ] リネーム機能でテキストエリアが正常に動作する
- [ ] カーソル移動（矢印キー、Home、End）が正常に動作する
- [ ] テキストの編集（Backspace、Delete）が正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)